### PR TITLE
Add PROT_READ to write access mode for FreeBSD compatibility

### DIFF
--- a/include/mio/detail/mmap.ipp
+++ b/include/mio/detail/mmap.ipp
@@ -208,7 +208,7 @@ inline mmap_context memory_map(const file_handle_type file_handle, const int64_t
     char* mapping_start = static_cast<char*>(::mmap(
             0, // Don't give hint as to where to map.
             length_to_map,
-            mode == access_mode::read ? PROT_READ : PROT_WRITE,
+            mode == access_mode::read ? PROT_READ : PROT_READ | PROT_WRITE,
             mode == access_mode::copy_on_write ? MAP_PRIVATE : MAP_SHARED,
             file_handle,
             aligned_offset));


### PR DESCRIPTION
On FreeBSD it's not enough to specify only PROT_WRITE if the memory shall also be read. It's necessary to also include PROT_READ in this case.

This is related to https://github.com/vimpunk/mio/issues/110 in the parent repository. All credits go to @oschonrock who provided this solution.